### PR TITLE
Change header due to original header error

### DIFF
--- a/fgodrop/__main__.py
+++ b/fgodrop/__main__.py
@@ -51,7 +51,7 @@ def get_section(area):
 
 
 def parse(values, version):
-    header = values[1:3]
+    header = values[38:40]
     # forward fill
     f = ''
     header[0] = [(f := i) if i else f for i in header[0]]


### PR DESCRIPTION
ドロップ率表の見出しのAPとデータ数が空欄になってしまっているので下の段の見出しを使う。