### PR TITLE
効率劇場のスプレッドシートIDを変更

### DIFF
--- a/fgodrop/__main__.py
+++ b/fgodrop/__main__.py
@@ -184,8 +184,8 @@ def get_values(spreadsheet_id, spreadsheet_range, api_key):
 
 def handler(event, context):
     #spreadsheet_id = '1DxFVWa1xsBh-TJVVTrJf7ttVxf7msCHhxuZyM-shPx0'
-    #spreadsheet_id = '1CmH3z71ymRJMlBO11cBthABxKuqdHrzXwiKa3cqRrMQ'
-    spreadsheet_id = '1qjiymRgcpdAYv201jdzcfRSPKrNaquNRJGIRYFlaimo'
+    spreadsheet_id = '1CmH3z71ymRJMlBO11cBthABxKuqdHrzXwiKa3cqRrMQ'
+    #spreadsheet_id = '1qjiymRgcpdAYv201jdzcfRSPKrNaquNRJGIRYFlaimo'
     values = get_values(
         spreadsheet_id=spreadsheet_id,
         spreadsheet_range=urllib.parse.quote('ドロップ率表'),


### PR DESCRIPTION
アイテムのカテゴリ名が消えてLambdaが停止していたので古い方のスプレッドシートを参照するように変更

![image](https://github.com/antenna-three/fgodrop/assets/18689785/3edcb78d-c4c2-4eb3-87d8-304c13951097)
